### PR TITLE
ASP.NET Core 3: IServiceCollection extensions namespace

### DIFF
--- a/src/3.0-JsonMergePatch.SystemText/SystemTextMvcBuilderExtensions.cs
+++ b/src/3.0-JsonMergePatch.SystemText/SystemTextMvcBuilderExtensions.cs
@@ -4,8 +4,9 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using System;
+using Morcatko.AspNetCore.JsonMergePatch.SystemText;
 
-namespace Morcatko.AspNetCore.JsonMergePatch.SystemText
+namespace Morcatko.AspNetCore.JsonMergePatch
 {
 	public static class SystemTextMvxBuilderExtensions
 	{

--- a/src/3.0-JsonMergePatch.SystemText/SystemTextMvcBuilderExtensions2.cs
+++ b/src/3.0-JsonMergePatch.SystemText/SystemTextMvcBuilderExtensions2.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using System;
+
+// Extensions in Morcatko.AspNetCore.JsonMergePatch.SystemText kept for retro-compatibility.
+
+namespace Morcatko.AspNetCore.JsonMergePatch.SystemText
+{
+	public static class SystemTextMvxBuilderExtensions
+	{
+        public static IMvcBuilder AddSystemTextJsonMergePatch(this IMvcBuilder builder, Action<JsonMergePatchOptions> configure = null)
+            => JsonMergePatch.SystemTextMvxBuilderExtensions.AddSystemTextJsonMergePatch(builder, configure);
+
+        public static IMvcCoreBuilder AddSystemTextJsonMergePatch(this IMvcCoreBuilder builder, Action<JsonMergePatchOptions> configure = null)
+            => JsonMergePatch.SystemTextMvxBuilderExtensions.AddSystemTextJsonMergePatch(builder, configure);
+    }
+}

--- a/src/3.0-JsonMergePatch.SystemText/SystemTextMvcBuilderExtensions2.cs
+++ b/src/3.0-JsonMergePatch.SystemText/SystemTextMvcBuilderExtensions2.cs
@@ -5,15 +5,16 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using System;
 
-// Extensions in Morcatko.AspNetCore.JsonMergePatch.SystemText kept for retro-compatibility.
-
 namespace Morcatko.AspNetCore.JsonMergePatch.SystemText
 {
+    [Obsolete("Moved to namespace Morcatko.AspNetCore.JsonMergePatch")]
 	public static class SystemTextMvxBuilderExtensions
 	{
+        [Obsolete("Moved to namespace Morcatko.AspNetCore.JsonMergePatch")]
         public static IMvcBuilder AddSystemTextJsonMergePatch(this IMvcBuilder builder, Action<JsonMergePatchOptions> configure = null)
             => JsonMergePatch.SystemTextMvxBuilderExtensions.AddSystemTextJsonMergePatch(builder, configure);
 
+        [Obsolete("Moved to namespace Morcatko.AspNetCore.JsonMergePatch")]
         public static IMvcCoreBuilder AddSystemTextJsonMergePatch(this IMvcCoreBuilder builder, Action<JsonMergePatchOptions> configure = null)
             => JsonMergePatch.SystemTextMvxBuilderExtensions.AddSystemTextJsonMergePatch(builder, configure);
     }


### PR DESCRIPTION
Hi,
I propose using namespace *Morcatko.AspNetCore.JsonMergePatch* instead of *Morcatko.AspNetCore.JsonMergePatch.SystemText* for extension methods on `IServiceCollection` to be on par with NewtonsoftJson version and with documentation.