### PR TITLE
Fix to patching decimals in JsonMergePatch.SystemText

### DIFF
--- a/src/3.0-JsonMergePatch.SystemText/Builders/PatchBuilder.cs
+++ b/src/3.0-JsonMergePatch.SystemText/Builders/PatchBuilder.cs
@@ -13,7 +13,7 @@ namespace Morcatko.AspNetCore.JsonMergePatch.SystemText.Builders
 			{
 				case JsonValueKind.Null: return null;
 				case JsonValueKind.String: return jsonElement.GetString();
-				case JsonValueKind.Number: return jsonElement.GetInt64();
+				case JsonValueKind.Number: return jsonElement.GetGenericNumber();
 				case JsonValueKind.True: return true;
 				case JsonValueKind.False: return false;
 				case JsonValueKind.Undefined:
@@ -22,6 +22,17 @@ namespace Morcatko.AspNetCore.JsonMergePatch.SystemText.Builders
 				default:
 					throw new NotSupportedException($"Unsupported ValueKind - {jsonElement.ValueKind}");
 			}
+		}
+
+		private static object GetGenericNumber (this JsonElement jsonElement)
+        {
+
+            // Attempt to parse the JSON Element as an Int32 first
+            if (jsonElement.TryGetInt32(out int int32)) return int32;
+
+            // Failing that, parse it as a Decimal instead
+            return jsonElement.GetDecimal();
+
 		}
 
 		private static bool IsValue(this JsonValueKind valueKind)

--- a/src/3.0-JsonMergePatch.Tests/Integration/MvcTest.cs
+++ b/src/3.0-JsonMergePatch.Tests/Integration/MvcTest.cs
@@ -119,6 +119,25 @@ namespace Morcatko.AspNetCore.JsonMergePatch.Tests.Integration
 			}
 		}
 
+		[Theory]
+		[MemberData(nameof(GetCombinations))]
+		public async Task NullableDecimalFloatingPoint(bool core, bool newtonsoft)
+		{
+			using (var p = new TestHelper(core, newtonsoft)) {
+				await p.PostAsync("0", p.GetTestModel());
+
+				await p.MergePatchAsync(null, new[]
+				{
+					new { id = 0, NullableDecimal = 7.5 }
+				});
+
+				var patchedModel = await p.GetAsync("0");
+				var expected = p.GetTestModel();
+				expected.NullableDecimal = (decimal?) 7.5;
+				Assert.Equal(expected, patchedModel);
+			}
+		}
+
 		[Theory(Skip = "Does not work")]
 		[MemberData(nameof(GetCombinations))]
 		public async Task MissingRequiredProperty(bool core, bool newtonsoft)


### PR DESCRIPTION
These are changes specific to the SystemText.JSON implementation of this framework

Developed to fix issue #38 

I have added a JSONElement extension `GetGenericNumber` to the SystemText Patch Builder

Previously it would cast all JSON numbers to an Int64 (even if they were decimal)

Now, it will _attempt_ to cast to an Int64 and failing that, will cast to a decimal instead

This should allow for patching of both integer and floating point numbers

I have also added a new test to demonstrate this working for both scenarios

@Morcatko - could you run your eyes over this and make sure I've not missed anything obvious ? Cheers